### PR TITLE
Add integration tests for external plugins

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -1,0 +1,23 @@
+---
+name: CI
+on:
+  pull_request:
+jobs:
+  tacas:
+    name: TACAS plus integration
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install test dependencies
+        run: pip install -r tools/test/test_requirements.txt
+
+      - name: Run integration checks
+        run: cd tools/test/integration && py.test test_tacacs.py -s

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -8,8 +8,9 @@ env:
 on:
   pull_request:
 jobs:
-  tacas:
+  external_tests:
     name: External integration tests
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'external_tests') }}
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -1,10 +1,15 @@
 ---
 name: CI
+env:
+  LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
+  CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  DEV_DOCKER_OWNER: ${{ github.repository_owner }}
+  COMPOSE_TAG: ${{ github.base_ref || 'devel' }}
 on:
   pull_request:
 jobs:
   tacas:
-    name: TACAS plus integration
+    name: External integration tests
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -13,11 +18,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
+
+      - name: Build image for use in tests
+        run: make github_ci_setup
 
       - name: Install test dependencies
         run: pip install -r tools/test/test_requirements.txt
 
       - name: Run integration checks
-        run: cd tools/test/integration && py.test test_tacacs.py -s
+        run: cd tools/test/integration && py.test . -s

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ clean-api:
 	find . -type f -regex ".*\.py[co]$$" -delete
 	find . -type d -name "__pycache__" -delete
 	rm -f awx/awx_test.sqlite3*
+	rm -f awx/awx.sqlite3*
 	rm -rf requirements/vendor
 	rm -rf awx/projects
 

--- a/awx/main/dispatch/publish.py
+++ b/awx/main/dispatch/publish.py
@@ -5,6 +5,7 @@ import time
 from uuid import uuid4
 
 from django_guid import get_guid
+from django.db import connection
 
 from . import pg_bus_conn
 from awx.main.utils import is_testing
@@ -74,6 +75,8 @@ class task:
 
             @classmethod
             def apply_async(cls, args=None, kwargs=None, queue=None, uuid=None, **kw):
+                if connection.vendor == 'sqlite':
+                    return
                 task_id = uuid or str(uuid4())
                 args = args or []
                 kwargs = kwargs or {}

--- a/awx/main/dispatch/publish.py
+++ b/awx/main/dispatch/publish.py
@@ -5,7 +5,6 @@ import time
 from uuid import uuid4
 
 from django_guid import get_guid
-from django.db import connection
 
 from . import pg_bus_conn
 from awx.main.utils import is_testing
@@ -75,8 +74,6 @@ class task:
 
             @classmethod
             def apply_async(cls, args=None, kwargs=None, queue=None, uuid=None, **kw):
-                if connection.vendor == 'sqlite':
-                    return
                 task_id = uuid or str(uuid4())
                 args = args or []
                 kwargs = kwargs or {}

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -154,7 +154,7 @@ def is_testing(argv=None):
     argv = sys.argv if argv is None else argv
     if len(argv) >= 1 and ('py.test' in argv[0] or 'py/test.py' in argv[0]):
         return True
-    elif len(argv) >= 2 and argv[1] == 'test':
+    elif len(argv) >= 2 and argv[1] in ('test', 'runserver'):
         return True
     return False
 

--- a/tools/test/README.md
+++ b/tools/test/README.md
@@ -2,46 +2,13 @@
 
 This is a location intended to offer some community-directed integration testing.
 
-#### Minimal AWX
-
 It is very standard for projects to offer a docker image which allows testing
 with the web service that the project provides.
-We have a set of tooling here which is intended to offer that for AWX itself.
 
-The intended use case is to test an AWX container in conjunction with
-another container from another integrated service.
-A secondary goal is that someone might find this useful to co-develop their
-own services, in their own repo, with AWX.
-
-For a manual experience, you can try this:
-
-```
-docker run --interactive \
-	--publish 8045:8045 \
-	-u $(id -u) --privileged --rm \
-	-v ./:/awx_devel \
-	-v ./tools/test/minimal_settings.py:/etc/tower/conf.d/minimal_settings.py \
-	-e AWX_LOGGING_MODE=stdout \
-	-e DJANGO_SUPERUSER_PASSWORD=password \
-	--name=hack_awx_1 \
-	ghcr.io/ansible/awx_devel:devel /awx_devel/tools/test/test_server.sh awx-manage runserver 8045
-```
-
-This will give a server located at `http://localhost:8045/` (not https) with
-a user/password combination of admin/password.
-
-Getting static files working with this is still TBD (so no UI, only API).
-Websockets are philosophically incompatible work with this approach.
-This doesn't run a task system (you could attach your own at great effort),
-and you can forget about receptor.
-If you wanted any of these things, see the existing docker-compose stuff.
-
-Running that `docker run` command will give an instance with a fresh database,
-even skipping the normal course of running migrations.
-
-### Automated Testing
-
-This is still very raw, but it works in a sense.
+You run these tests _outside_ of the container on your own machine.
+You need to cd into the directory in order to pick up its unique pytest config.
+These tests will pull images, run containers, and tear down the containers at the end.
+These steps correspond to the `.github/workflows/ci_integration.yml` steps:
 
 ```
 pip install -r tools/test/test_requirements.txt
@@ -49,4 +16,13 @@ cd tools/test/integration
 py.test . -s
 ```
 
-That will run the AWX container.
+The `-s` will print stdout, which should include logs from the containers.
+
+### Debugging Tips
+
+If you insert a `pdb.set_trace()` into a test, you can catch it with the
+severs running actively in the background.
+The AWX server should be available at `http://localhost:8045/` (not https) with
+a user/password combination of admin/password.
+
+Static files (and many other things) are not expected to work.

--- a/tools/test/README.md
+++ b/tools/test/README.md
@@ -1,0 +1,52 @@
+### Integration Testing
+
+This is a location intended to offer some community-directed integration testing.
+
+#### Minimal AWX
+
+It is very standard for projects to offer a docker image which allows testing
+with the web service that the project provides.
+We have a set of tooling here which is intended to offer that for AWX itself.
+
+The intended use case is to test an AWX container in conjunction with
+another container from another integrated service.
+A secondary goal is that someone might find this useful to co-develop their
+own services, in their own repo, with AWX.
+
+For a manual experience, you can try this:
+
+```
+docker run --interactive \
+	--publish 8045:8045 \
+	-u $(id -u) --privileged --rm \
+	-v ./:/awx_devel \
+	-v ./tools/test/minimal_settings.py:/etc/tower/conf.d/minimal_settings.py \
+	-e AWX_LOGGING_MODE=stdout \
+	-e DJANGO_SUPERUSER_PASSWORD=password \
+	--name=hack_awx_1 \
+	ghcr.io/ansible/awx_devel:devel /awx_devel/tools/test/test_server.sh awx-manage runserver 8045
+```
+
+This will give a server located at `http://localhost:8045/` (not https) with
+a user/password combination of admin/password.
+
+Getting static files working with this is still TBD (so no UI, only API).
+Websockets are philosophically incompatible work with this approach.
+This doesn't run a task system (you could attach your own at great effort),
+and you can forget about receptor.
+If you wanted any of these things, see the existing docker-compose stuff.
+
+Running that `docker run` command will give an instance with a fresh database,
+even skipping the normal course of running migrations.
+
+### Automated Testing
+
+This is still very raw, but it works in a sense.
+
+```
+pip install -r tools/test/test_requirements.txt
+cd tools/test/integration
+py.test . -s
+```
+
+That will run the AWX container.

--- a/tools/test/integration/conftest.py
+++ b/tools/test/integration/conftest.py
@@ -1,0 +1,105 @@
+import os
+import time
+
+from docker.errors import ImageNotFound
+from docker import from_env
+import pytest
+import requests
+
+from awxkit.api import get_registered_page
+from awxkit.api.client import Connection
+
+
+COMMON_CONTAINER_KWARGS = dict(
+    detach=True,
+    # remove=True,  # If container exits early, we still want to get logs
+)
+
+
+@pytest.fixture(scope='session')
+def docker_client():
+    return from_env()
+
+
+@pytest.fixture(scope='session')
+def base_path():
+    integration_dir = os.path.dirname(os.path.abspath(__file__))
+    test_dir = os.path.join(integration_dir, os.pardir)
+    tools_dir = os.path.join(test_dir, os.pardir)
+    repo_root = os.path.join(tools_dir, os.pardir)
+    return os.path.abspath(repo_root)
+
+
+@pytest.fixture(scope='session')
+def container_factory(request, docker_client, base_path):
+    """Helper method for creating an arbitrary container, integrating with pytest"""
+
+    def run_this_container(image_name, image_options, command=None):
+        name = image_options['name']
+        # Pull the image if it does not exist locally
+        try:
+            docker_client.images.get(image_name)
+        except ImageNotFound:
+            docker_client.images.pull(image_name)
+
+        args = [image_name]
+        if command is not None:
+            args.append(command)
+        container = docker_client.containers.run(*args, **image_options, **COMMON_CONTAINER_KWARGS)
+
+        def kill_this_container():
+            print('')
+            print(f'{name} container logs:')
+            print(str(container.logs(), encoding='utf-8'))
+            container.stop()
+            container.remove()
+
+        request.addfinalizer(kill_this_container)
+        return container
+
+    return run_this_container
+
+
+@pytest.fixture(scope='session')
+def awx_server_no_wait(container_factory, base_path):
+    return container_factory(
+        'ghcr.io/ansible/awx_devel:devel',
+        dict(
+            user=os.getuid(),
+            # ports={'8045/tcp': '8045'},  # need if you do not use host network_mode
+            environment=['AWX_LOGGING_MODE=stdout', 'DJANGO_SUPERUSER_PASSWORD=password'],
+            volumes={
+                base_path: {'bind': '/awx_devel', 'mode': 'rw'},
+                f'{base_path}/tools/test/minimal_settings.py': {'bind': '/etc/tower/conf.d/minimal_settings.py', 'mode': 'rw'},
+            },
+            name='hack_awx_1',
+            network_mode='host',  # to talk to the other containers
+        ),
+        command='/awx_devel/tools/test/test_server.sh awx-python manage.py runserver 8045',
+    )
+
+
+@pytest.fixture(scope='session')
+def awx_server(awx_server_no_wait):
+    print('Waiting for AWX to be running')
+    for i in range(30):
+        try:
+            r = requests.get('http://localhost:8045/api/v2/', verify=False, timeout=5)
+        except Exception:
+            time.sleep(1)
+            print('.')
+            continue
+        print('\nserver is up and running now')
+        assert "system_job_templates" in r.text  # minimal sanity assertion
+        break
+    else:
+        raise Exception('AWX sever never came up')
+    return awx_server_no_wait
+
+
+@pytest.fixture(scope='session')
+def v2(awx_server):
+    url = 'http://localhost:8045/'
+    conn = Connection(url, verify=False)
+    conn.login(username='admin', password='password')
+    return get_registered_page('/api/v2/')(conn, endpoint='/api/v2/').get()

--- a/tools/test/integration/conftest.py
+++ b/tools/test/integration/conftest.py
@@ -10,12 +10,6 @@ from awxkit.api import get_registered_page
 from awxkit.api.client import Connection
 
 
-COMMON_CONTAINER_KWARGS = dict(
-    detach=True,
-    # remove=True,  # If container exits early, we still want to get logs
-)
-
-
 @pytest.fixture(scope='session')
 def docker_client():
     return from_env()
@@ -42,10 +36,12 @@ def container_factory(request, docker_client, base_path):
         except ImageNotFound:
             docker_client.images.pull(image_name)
 
+        # Need to run in detach mode because service needs to be persistent through tests
+        image_options['detach'] = True
         args = [image_name]
         if command is not None:
             args.append(command)
-        container = docker_client.containers.run(*args, **image_options, **COMMON_CONTAINER_KWARGS)
+        container = docker_client.containers.run(*args, **image_options)
 
         def kill_this_container():
             print('')
@@ -62,12 +58,22 @@ def container_factory(request, docker_client, base_path):
 
 @pytest.fixture(scope='session')
 def awx_server_no_wait(container_factory, base_path):
+    """
+    The container options used here mirror the Makefile docker-runner target
+    Additional customizations include:
+     - bootstrapping migrations, install, db, cache, etc. with custom settings and script
+     - networking so that server can be accessed, and container can talk to other local containers
+    """
+    org = os.getenv('DEV_DOCKER_OWNER', 'ansible').lower()
+    tag = os.getenv('COMPOSE_TAG', 'devel')
+    image_name = f'ghcr.io/{org}/awx_devel:{tag}'
+    print(f'Using AWX image {image_name}')
     return container_factory(
-        'ghcr.io/ansible/awx_devel:devel',
+        image_name,
         dict(
             user=os.getuid(),
             # ports={'8045/tcp': '8045'},  # need if you do not use host network_mode
-            environment=['AWX_LOGGING_MODE=stdout', 'DJANGO_SUPERUSER_PASSWORD=password'],
+            environment=['AWX_LOGGING_MODE=stdout'],  # superuser created in migration hack
             volumes={
                 base_path: {'bind': '/awx_devel', 'mode': 'rw'},
                 f'{base_path}/tools/test/minimal_settings.py': {'bind': '/etc/tower/conf.d/minimal_settings.py', 'mode': 'rw'},

--- a/tools/test/integration/test_awx_server.py
+++ b/tools/test/integration/test_awx_server.py
@@ -1,0 +1,10 @@
+import pytest
+
+from awxkit.exceptions import Unauthorized
+from awxkit.awx.utils import as_user
+
+
+def test_login_as_invalid_user(v2):
+    with as_user(v2.connection, username='fake_user', password='fake_pass'):
+        with pytest.raises(Unauthorized):
+            v2.me.get()

--- a/tools/test/integration/test_tacacs.py
+++ b/tools/test/integration/test_tacacs.py
@@ -34,7 +34,7 @@ def test_confirm_tacacs_host_and_secret_required(v2):
     assert e.value.msg == {'__all__': ['TACACSPLUS_SECRET is required when TACACSPLUS_HOST is provided.']}
 
 
-def test_timeout_of_tacacs_server(request, v2, tacacs_settings):
+def test_timeout_of_tacacs(request, v2, tacacs_settings):
     user = v2.users.create(username='iosadmin', password='cisco', is_superuser=False)
     request.addfinalizer(user.silent_delete)
 

--- a/tools/test/integration/test_tacacs.py
+++ b/tools/test/integration/test_tacacs.py
@@ -1,0 +1,132 @@
+import os
+import json
+import time
+
+import pytest
+
+from awxkit.awx.utils import as_user
+from awxkit.exceptions import Unauthorized, BadRequest
+
+
+@pytest.fixture(scope='class')
+def tacacs_server_no_wait(container_factory):
+    return container_factory('dchidell/docker-tacacs', dict(ports={'49/tcp': '49'}, name='hack_tacacs_1'))
+
+
+@pytest.fixture(scope='class')
+def tacacs_server(tacacs_server_no_wait):
+    return tacacs_server_no_wait
+
+
+@pytest.fixture(scope='session')
+def tacacs_settings(base_path):
+    settings_path = os.path.join(base_path, 'tools/docker-compose/ansible/templates/tacacsplus_settings.json.j2')
+    with open(settings_path, 'r') as f:
+        data = json.load(f)
+    data["TACACSPLUS_HOST"] = "127.0.0.1"
+    return data
+
+
+def test_confirm_tacacs_host_and_secret_required(v2):
+    settings_pg = v2.settings.get().get_endpoint('tacacsplus')
+    with pytest.raises(BadRequest) as e:
+        settings_pg.patch(TACACSPLUS_HOST='127.0.0.1')
+    assert e.value.msg == {'__all__': ['TACACSPLUS_SECRET is required when TACACSPLUS_HOST is provided.']}
+
+
+def test_timeout_of_tacacs_server(request, v2, tacacs_settings):
+    user = v2.users.create(username='iosadmin', password='cisco', is_superuser=False)
+    request.addfinalizer(user.silent_delete)
+
+    setting_pg = v2.settings.get().get_endpoint('tacacsplus')
+    request.addfinalizer(setting_pg.silent_delete)
+    new_settings = tacacs_settings.copy()
+    new_settings.update(dict(TACACSPLUS_HOST='169.254.1.0', TACACSPLUS_SESSION_TIMEOUT=20))
+    setting_pg.patch(**new_settings)
+
+    start = time.time()
+    # AWX should first attempt to authenticate using TACACS+ server, then use local login
+    with as_user(v2.connection, username='iosadmin', password='cisco'):
+        v2.me.get()
+    login_time = time.time() - start
+
+    assert login_time > 20
+    assert login_time < 25
+
+
+class TestTACACSPlus:
+    """
+    Integration testing with AWX and TACACS Plus, where integration is pre-configured
+    TODO:
+     - using ascii vs pap protocol
+    """
+
+    @pytest.fixture(scope='class', autouse=True)
+    def plumb_tacacs(self, request, v2, tacacs_settings, tacacs_server):
+        setting_pg = v2.settings.get().get_endpoint('tacacsplus')
+        request.addfinalizer(setting_pg.silent_delete)
+        setting_pg.patch(**tacacs_settings)
+
+    def test_login_as_new_user(self, request, v2):
+        assert not v2.users.get(username='iosadmin').count
+
+        # Core test assertion - accounts are from
+        # https://hub.docker.com/r/dchidell/docker-tacacs
+        with as_user(v2.connection, username='iosadmin', password='cisco'):
+            me_page = v2.me.get()
+            user = me_page.results[0].get()
+            assert 'iosadmin' == user.username
+            request.addfinalizer(user.silent_delete)
+
+        assert len(v2.users.get(username='iosadmin').results) == 1
+
+    def test_username_change_with_tacacs_auth(self, request, v2):
+        assert not v2.users.get(username='iosadmin').count
+
+        with as_user(v2.connection, username='iosadmin', password='cisco'):
+            user = v2.me.get().results.pop()
+            request.addfinalizer(user.silent_delete)
+            first_user_id = user.id
+            user.first_name = 'changed'
+            v2.connection.logout()
+
+        with as_user(v2.connection, username='iosadmin', password='cisco'):
+            user = v2.me.get().results.pop()
+            assert first_user_id == user.id
+            assert user.get().first_name == 'changed'
+
+    def test_login_as_pre_existing_user(self, request, v2):
+        """
+        If the user has already been created with a different password as a manual user
+        then the username-password from TACACS Plus should not work
+        and the normal username-password should continue to work
+        """
+        user = v2.users.create(username='iosadmin', password='random_password', is_superuser=False)
+        request.addfinalizer(user.silent_delete)
+
+        with as_user(v2.connection, username='iosadmin', password='cisco'):
+            with pytest.raises(Unauthorized):
+                v2.me.get()
+
+        with as_user(v2.connection, username='iosadmin', password='random_password'):
+            v2.me.get()
+
+    def test_invalid_user_with_tacacs_plus_enabled(self, v2):
+        with as_user(v2.connection, username='fake_user', password='fake_pass'):
+            with pytest.raises(Unauthorized):
+                v2.me.get()
+
+    def test_cannot_change_password_for_tacacs_user_in_AWX(self, request, v2):
+        assert not v2.users.get(username='iosadmin').count
+
+        with as_user(v2.connection, username='iosadmin', password='cisco'):
+            user = v2.users.get(username='iosadmin').results.pop()
+            request.addfinalizer(user.silent_delete)
+            user.patch(password='shouldntw0rk')
+
+        with pytest.raises(Unauthorized):
+            with as_user(v2.connection, username='iosadmin', password='shouldntw0rk'):
+                v2.me.get()
+
+        with as_user(v2.connection, username='iosadmin', password='cisco'):
+            v2.me.get()

--- a/tools/test/minimal_settings.py
+++ b/tools/test/minimal_settings.py
@@ -43,3 +43,6 @@ CACHES = {
 
 # Allow for database reuse
 SECRET_KEY = "pGT9A9U59ajcxkVlmUiVZPK6JcgX+M6VjVru5nPY0ws="
+
+# Make sure that we do not run Django debug toolbar by accident
+INTERNAL_IPS = ()

--- a/tools/test/minimal_settings.py
+++ b/tools/test/minimal_settings.py
@@ -1,0 +1,39 @@
+# Remove annoying things that require pre-loaded data which we do not want anyway
+MIDDLEWARE.remove('awx.main.middleware.MigrationRanCheckMiddleware')  # NOQA
+INSTALLED_APPS.remove('django.contrib.sites')  # NOQA
+
+
+# Monkey patch the migration command to our hack that migrates straight to current schema
+from django.core.management.commands import migrate
+
+
+# For background on where this method comes from, see Django testing setup
+# https://github.com/django/django/blob/c813fb327cb1b09542be89c5ceed367826236bc2/django/db/backends/base/creation.py#L32
+class MigrateToCurrent(migrate.Command):
+    help = 'Hacked migration - creates tables to match current models'
+
+    def handle(self, *args, **options):
+        from django.apps import apps
+        from django.conf import settings
+
+        settings.MIGRATION_MODULES = {app.label: None for app in apps.get_app_configs()}
+        options['run_syncdb'] = True
+        super().handle(*args, **options)
+
+        from awx.main.models.credential import CredentialType
+
+        CredentialType.setup_tower_managed_defaults(apps)
+
+
+migrate.Command = MigrateToCurrent
+
+# Get rid of redis cache, do not need it for minimal deploy
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "unique-snowflake",
+    }
+}
+
+# Allow for database reuse
+SECRET_KEY = "pGT9A9U59ajcxkVlmUiVZPK6JcgX+M6VjVru5nPY0ws="

--- a/tools/test/minimal_settings.py
+++ b/tools/test/minimal_settings.py
@@ -1,12 +1,12 @@
+from django.core.management.commands import migrate
+
+
 # Remove annoying things that require pre-loaded data which we do not want anyway
 MIDDLEWARE.remove('awx.main.middleware.MigrationRanCheckMiddleware')  # NOQA
 INSTALLED_APPS.remove('django.contrib.sites')  # NOQA
 
 
 # Monkey patch the migration command to our hack that migrates straight to current schema
-from django.core.management.commands import migrate
-
-
 # For background on where this method comes from, see Django testing setup
 # https://github.com/django/django/blob/c813fb327cb1b09542be89c5ceed367826236bc2/django/db/backends/base/creation.py#L32
 class MigrateToCurrent(migrate.Command):
@@ -20,8 +20,14 @@ class MigrateToCurrent(migrate.Command):
         options['run_syncdb'] = True
         super().handle(*args, **options)
 
+        # Preload certain data here which can be used by tests
+        from django.contrib.auth import get_user_model
         from awx.main.models.credential import CredentialType
 
+        User = get_user_model()
+
+        if not User.objects.filter(username='admin').exists():
+            User.objects.create_superuser('admin', 'admin@localhost', 'password')
         CredentialType.setup_tower_managed_defaults(apps)
 
 

--- a/tools/test/test_requirements.txt
+++ b/tools/test/test_requirements.txt
@@ -1,0 +1,3 @@
+docker
+pytest
+-e awxkit/

--- a/tools/test/test_server.sh
+++ b/tools/test/test_server.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set +x
+
+cd /awx_devel
+
+make awx-link
+
+awx-manage migrate --noinput -v0
+
+awx-manage createsuperuser --noinput --username=admin --email=admin@localhost
+
+exec $@

--- a/tools/test/test_server.sh
+++ b/tools/test/test_server.sh
@@ -7,6 +7,4 @@ make awx-link
 
 awx-manage migrate --noinput -v0
 
-awx-manage createsuperuser --noinput --username=admin --email=admin@localhost
-
 exec $@


### PR DESCRIPTION
##### SUMMARY
The current proposed workflow, subject to change:

 - If someone makes a change that we think deals with external integrations, then we apply the "external_tests" label
 - After apply the label, we re-run the checks so that it picks up
 - Subsequently, these will run on every push, and we can (presumably) ask the contributor to add or expand on some tests

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API
