### PR TITLE
fix: credential association and remove quote filter

### DIFF
--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -207,7 +207,7 @@ def project_factory(post, default_org, admin):
 
 @pytest.fixture
 def run_job_from_playbook(demo_inv, post, admin, project_factory):
-    def _rf(test_name, playbook, local_path=None, scm_url=None, jt_params=None, proj=None, wait=True):
+    def _rf(test_name, playbook, local_path=None, scm_url=None, jt_params=None, proj=None, wait=True, credentials=None):
         jt_name = f'{test_name} JT: {playbook}'
 
         if not proj:
@@ -235,6 +235,8 @@ def run_job_from_playbook(demo_inv, post, admin, project_factory):
             expect=201,
         )
         jt = JobTemplate.objects.get(id=result.data['id'])
+        if credentials:
+            jt.credentials.add(*credentials)
         job = jt.create_unified_job()
         job.signal_start()
 

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -23,7 +23,7 @@ def custom_cred_type(default_org):
                 }
             ]
         },
-        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename.custom_file | quote }}'}},
+        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename.custom_file }}'}},
     )
     cred_type.save()
     return cred_type
@@ -58,7 +58,7 @@ def test_custom_credential_type_file_injection(
         test_name='custom_credential_type',
         playbook='test_cred.yml',
         scm_url=f'file://{live_tmp_folder}/custom_cred_project',
-        jt_params={'credentials': [custom_credential.id]},
+        credentials=[custom_credential],
     )
 
     job = result['job']


### PR DESCRIPTION
Two fixes to make the live test pass:

### 1. Credential association
`credentials` passed in `jt_params` is silently ignored by the JT creation API — it's not a writable field on the JobTemplate serializer. The job ran without any credentials attached, so file injection never occurred.

Fixed by using `jt.credentials.add()` to associate the credential with the JT before creating the job.

### 2. Remove `| quote` filter
The Jinja2 sandbox used for credential injection (`ImmutableSandboxedEnvironment` in `awx_plugins`) does not have the `quote` filter registered. Rendering `{{ tower.filename.custom_file | quote }}` would fail with a template error. The test never hit this because it failed earlier on the credential association issue.

Removed `| quote` from the injector definition — base file injection works without it.

### CI verification
Both fixes verified green in ansible/awx#16487 (now closed) — all 19 CI checks passed including the `dev-env` live test suite.